### PR TITLE
Suggest 'docker-compose up' command when a docker-compose.yml exists

### DIFF
--- a/src/config-inferrer.ts
+++ b/src/config-inferrer.ts
@@ -11,12 +11,13 @@ export class ConfigInferrer {
     protected contributions: ((ctx: Context) => Promise<void>)[] = [
         this.checkNode.bind(this),
         this.checkJava.bind(this),
+        this.checkMake.bind(this),
         this.checkPython.bind(this),
         this.checkGo.bind(this),
         this.checkRust.bind(this),
-        this.checkMake.bind(this),
         this.checkNuget.bind(this),
         this.checkRuby.bind(this),
+        this.checkDockerCompose.bind(this),
     ]
 
     async getConfig(ctx: Context): Promise<WorkspaceConfig> {
@@ -143,6 +144,12 @@ export class ConfigInferrer {
             this.addCommand(ctx.config, 'bin/startup', 'command');
         } else if (await ctx.exists('bin/rails')) {
             this.addCommand(ctx.config, 'bin/rails server', 'command');
+        }
+    }
+
+    protected async checkDockerCompose(ctx: Context) {
+        if (await ctx.exists('docker-compose.yml')) {
+            this.addCommand(ctx.config, 'docker-compose up', 'command');
         }
     }
 


### PR DESCRIPTION
This could be cool, but I'm not sure if it's always helpful.

For example, in https://github.com/gitpod-io/spring-petclinic there is a [docker-compose.yml](https://github.com/gitpod-io/spring-petclinic/blob/master/docker-compose.yml), but [.gitpod.yml](https://github.com/gitpod-io/spring-petclinic/blob/master/.gitpod.yml) doesn't run `docker-compose up`.